### PR TITLE
Add onboarding screen layout

### DIFF
--- a/ios/NudgeBud/NudgeBud/ContentView.swift
+++ b/ios/NudgeBud/NudgeBud/ContentView.swift
@@ -6,56 +6,19 @@
 //
 
 import SwiftUI
-import SwiftData
 
 struct ContentView: View {
-    @Environment(\.modelContext) private var modelContext
-    @Query private var items: [Item]
-
     var body: some View {
-        NavigationSplitView {
-            List {
-                ForEach(items) { item in
-                    NavigationLink {
-                        Text("Item at \(item.timestamp, format: Date.FormatStyle(date: .numeric, time: .standard))")
-                    } label: {
-                        Text(item.timestamp, format: Date.FormatStyle(date: .numeric, time: .standard))
-                    }
-                }
-                .onDelete(perform: deleteItems)
-            }
-            .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    EditButton()
-                }
-                ToolbarItem {
-                    Button(action: addItem) {
-                        Label("Add Item", systemImage: "plus")
-                    }
-                }
-            }
-        } detail: {
-            Text("Select an item")
-        }
-    }
-
-    private func addItem() {
-        withAnimation {
-            let newItem = Item(timestamp: Date())
-            modelContext.insert(newItem)
-        }
-    }
-
-    private func deleteItems(offsets: IndexSet) {
-        withAnimation {
-            for index in offsets {
-                modelContext.delete(items[index])
-            }
-        }
+        OnboardingView()
     }
 }
 
-#Preview {
+#Preview("Light") {
     ContentView()
-        .modelContainer(for: Item.self, inMemory: true)
+        .environment(\.colorScheme, .light)
+}
+
+#Preview("Dark") {
+    ContentView()
+        .environment(\.colorScheme, .dark)
 }

--- a/ios/NudgeBud/NudgeBud/DesignTokens.swift
+++ b/ios/NudgeBud/NudgeBud/DesignTokens.swift
@@ -1,0 +1,69 @@
+//
+//  DesignTokens.swift
+//  NudgeBud
+//
+//  Created by OpenAI's ChatGPT on 11/5/25.
+//
+
+import SwiftUI
+
+enum DesignTokens {
+    enum Colors {
+        static let surfaceLight = Color(red: 247/255, green: 248/255, blue: 250/255)
+        static let surfaceDark = Color(red: 15/255, green: 17/255, blue: 21/255)
+        static let surfaceElevatedLight = Color(red: 1, green: 1, blue: 1)
+        static let surfaceElevatedDark = Color(red: 26/255, green: 29/255, blue: 34/255)
+        static let onSurfaceLight = Color(red: 15/255, green: 17/255, blue: 21/255)
+        static let onSurfaceDark = Color(red: 233/255, green: 236/255, blue: 242/255)
+        static let primaryLight = Color(red: 91/255, green: 110/255, blue: 255/255)
+        static let primaryDark = Color(red: 124/255, green: 135/255, blue: 255/255)
+        static let onPrimaryLight = Color(red: 255/255, green: 255/255, blue: 255/255)
+        static let onPrimaryDark = Color(red: 11/255, green: 12/255, blue: 16/255)
+        static let outlineLight = Color.black.opacity(0.12)
+        static let outlineDark = Color.white.opacity(0.16)
+        static let chipSelectedBgLight = Color(red: 233/255, green: 236/255, blue: 255/255)
+        static let chipSelectedBgDark = Color(red: 42/255, green: 47/255, blue: 58/255)
+
+        static func surface(for colorScheme: ColorScheme) -> Color {
+            colorScheme == .dark ? surfaceDark : surfaceLight
+        }
+
+        static func surfaceElevated(for colorScheme: ColorScheme) -> Color {
+            colorScheme == .dark ? surfaceElevatedDark : surfaceElevatedLight
+        }
+
+        static func onSurface(for colorScheme: ColorScheme) -> Color {
+            colorScheme == .dark ? onSurfaceDark : onSurfaceLight
+        }
+
+        static func primary(for colorScheme: ColorScheme) -> Color {
+            colorScheme == .dark ? primaryDark : primaryLight
+        }
+
+        static func onPrimary(for colorScheme: ColorScheme) -> Color {
+            colorScheme == .dark ? onPrimaryDark : onPrimaryLight
+        }
+
+        static func outline(for colorScheme: ColorScheme) -> Color {
+            colorScheme == .dark ? outlineDark : outlineLight
+        }
+
+        static func chipSelectedBackground(for colorScheme: ColorScheme) -> Color {
+            colorScheme == .dark ? chipSelectedBgDark : chipSelectedBgLight
+        }
+    }
+
+    enum Radii {
+        static let medium: CGFloat = 16
+    }
+
+    enum Layout {
+        static let maxContentWidth: CGFloat = 480
+    }
+}
+
+extension View {
+    func onboardingCardShadow(colorScheme: ColorScheme) -> some View {
+        shadow(color: colorScheme == .dark ? Color.black.opacity(0.6) : Color.black.opacity(0.14), radius: 12, x: 0, y: 6)
+    }
+}

--- a/ios/NudgeBud/NudgeBud/OnboardingView.swift
+++ b/ios/NudgeBud/NudgeBud/OnboardingView.swift
@@ -1,0 +1,168 @@
+//
+//  OnboardingView.swift
+//  NudgeBud
+//
+//  Created by OpenAI's ChatGPT on 11/5/25.
+//
+
+import SwiftUI
+
+struct OnboardingView: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        ZStack {
+            // We fill the background with the surface color so the view
+            // seamlessly matches the design token palette in both themes.
+            DesignTokens.Colors.surface(for: colorScheme)
+                .ignoresSafeArea()
+
+            ScrollView {
+                VStack(spacing: 32) {
+                    heroCard
+                    copySection
+                    actionButton
+                    secondaryAction
+                }
+                // Keeping the layout centered and readable on large iPads.
+                .frame(maxWidth: DesignTokens.Layout.maxContentWidth)
+                .padding(.horizontal, 24)
+                .padding(.vertical, 48)
+                .frame(maxWidth: .infinity)
+            }
+        }
+    }
+
+    private var heroCard: some View {
+        ZStack {
+            // Elevated surface uses a rounded rectangle to echo the figma card.
+            RoundedRectangle(cornerRadius: DesignTokens.Radii.medium, style: .continuous)
+                .fill(DesignTokens.Colors.surfaceElevated(for: colorScheme))
+                .overlay(
+                    // A subtle border prevents the card from blending into the background.
+                    RoundedRectangle(cornerRadius: DesignTokens.Radii.medium, style: .continuous)
+                        .stroke(DesignTokens.Colors.outline(for: colorScheme))
+                )
+
+            VStack(alignment: .leading, spacing: 16) {
+                // Hero illustration approximates the gradient blob from the design.
+                ZStack {
+                    Circle()
+                        .fill(DesignTokens.Colors.primary(for: colorScheme).opacity(0.18))
+                        .frame(width: 160, height: 160)
+                        .offset(x: 40, y: -40)
+
+                    RoundedRectangle(cornerRadius: 120, style: .continuous)
+                        .fill(
+                            LinearGradient(
+                                colors: [DesignTokens.Colors.primary(for: colorScheme), DesignTokens.Colors.primary(for: colorScheme).opacity(0.4)],
+                                startPoint: .topLeading,
+                                endPoint: .bottomTrailing
+                            )
+                        )
+                        .frame(width: 220, height: 180)
+                        .rotationEffect(.degrees(-12))
+
+                    Image(systemName: "sparkles")
+                        .font(.system(size: 42, weight: .semibold))
+                        .foregroundStyle(DesignTokens.Colors.onPrimary(for: colorScheme))
+                        .padding(20)
+                        .background(
+                            Circle().fill(DesignTokens.Colors.primary(for: colorScheme))
+                        )
+                        .shadow(color: DesignTokens.Colors.primary(for: colorScheme).opacity(0.35), radius: 12, x: 0, y: 10)
+                }
+                .frame(maxWidth: .infinity)
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("All your nudges in one calm place")
+                        .font(.title2.bold())
+                        .foregroundStyle(DesignTokens.Colors.onSurface(for: colorScheme))
+
+                    Text("Plan gentle reminders, share progress with your accountability crew, and celebrate wins without the noise.")
+                        .font(.body)
+                        .foregroundStyle(DesignTokens.Colors.onSurface(for: colorScheme).opacity(0.72))
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            .padding(28)
+        }
+        .onboardingCardShadow(colorScheme: colorScheme)
+    }
+
+    private var copySection: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Why you’ll love NudgeBud")
+                .font(.headline)
+                .foregroundStyle(DesignTokens.Colors.onSurface(for: colorScheme))
+
+            VStack(alignment: .leading, spacing: 12) {
+                featureRow(icon: "bell.badge", title: "Thoughtful nudges", detail: "Schedule reminders that respect focus time and avoid overload.")
+                featureRow(icon: "person.2.fill", title: "Shared journeys", detail: "Loop in friends for accountability and see progress at a glance.")
+                featureRow(icon: "sparkle.magnifyingglass", title: "Celebrate growth", detail: "Capture reflections so every tiny win gets the spotlight it deserves.")
+            }
+        }
+    }
+
+    private var actionButton: some View {
+        Button(action: {}) {
+            // Using maxWidth ensures the button feels prominent on the first screen.
+            Text("Create my first nudge")
+                .font(.headline)
+                .foregroundStyle(DesignTokens.Colors.onPrimary(for: colorScheme))
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 16)
+                .background(
+                    RoundedRectangle(cornerRadius: 14, style: .continuous)
+                        .fill(DesignTokens.Colors.primary(for: colorScheme))
+                )
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("onboarding_primary_cta")
+    }
+
+    private var secondaryAction: some View {
+        Button(action: {}) {
+            Text("I’ll explore first")
+                .font(.subheadline)
+                .foregroundStyle(DesignTokens.Colors.primary(for: colorScheme))
+        }
+        .buttonStyle(.plain)
+        .padding(.top, -12)
+    }
+
+    private func featureRow(icon: String, title: String, detail: String) -> some View {
+        HStack(alignment: .top, spacing: 16) {
+            // The icon sits on a chip background that adapts between light and dark.
+            Image(systemName: icon)
+                .font(.title3)
+                .foregroundStyle(DesignTokens.Colors.primary(for: colorScheme))
+                .padding(12)
+                .background(
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .fill(DesignTokens.Colors.chipSelectedBackground(for: colorScheme))
+                )
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(.subheadline.bold())
+                    .foregroundStyle(DesignTokens.Colors.onSurface(for: colorScheme))
+
+                Text(detail)
+                    .font(.footnote)
+                    .foregroundStyle(DesignTokens.Colors.onSurface(for: colorScheme).opacity(0.72))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+}
+
+#Preview("Onboarding – Light") {
+    OnboardingView()
+        .environment(\.colorScheme, .light)
+}
+
+#Preview("Onboarding – Dark") {
+    OnboardingView()
+        .environment(\.colorScheme, .dark)
+}


### PR DESCRIPTION
## Summary
- create shared design tokens so the onboarding screen can respect light and dark palettes
- replace the template list view with a SwiftUI onboarding layout and inline documentation comments
- build the first onboarding screen with hero illustration, benefits list, and call-to-action button

## Testing
- Not run (xcodebuild unavailable in container)

## Screenshots
- Light Mode – iPhone: _Unable to capture in container environment_
- Dark Mode – iPhone: _Unable to capture in container environment_
- Light Mode – iPad (XL): _Unable to capture in container environment_

------
https://chatgpt.com/codex/tasks/task_e_690c0ee87c04832491f45fc97c6ead46