### PR TITLE
Resolve HomeView preview access issues

### DIFF
--- a/ios/NudgeBud/NudgeBud/HomeView.swift
+++ b/ios/NudgeBud/NudgeBud/HomeView.swift
@@ -157,6 +157,13 @@ struct HomeView: View {
     }
 }
 
+extension HomeView {
+    init() {
+        _isPresentingTaskPicker = State(initialValue: false)
+        _selectedVibe = State(initialValue: .calmFocus)
+    }
+}
+
 private struct TaskCardView: View {
     let task: TaskCard
     let colorScheme: ColorScheme
@@ -262,7 +269,7 @@ private enum VibeOption: String, CaseIterable, Identifiable {
     }
 }
 
-struct TaskPickerSheet: View {
+private struct TaskPickerSheet: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.colorScheme) private var colorScheme
     @Binding var selectedVibe: VibeOption
@@ -341,6 +348,12 @@ struct TaskPickerSheet: View {
     }
 }
 
+extension TaskPickerSheet {
+    init(selectedVibe: Binding<VibeOption>) {
+        self._selectedVibe = selectedVibe
+    }
+}
+
 private struct VibeTemplate: Identifiable {
     let id = UUID()
     let vibe: VibeOption
@@ -357,7 +370,7 @@ private struct VibeTemplate: Identifiable {
         .preferredColorScheme(.dark)
 }
 
-#Preview("Home – XL", traits: .previewLayout(.fixed(width: 1024, height: 768))) {
+#Preview("Home – XL", traits: .fixedLayout(width: 1024, height: 768)) {
     HomeView()
         .preferredColorScheme(.light)
 }


### PR DESCRIPTION
## Summary
- add explicit initializers for HomeView and TaskPickerSheet to avoid exposing private helper types
- mark TaskPickerSheet as private and keep helper data scoped to the file
- update the XL preview to use the fixedLayout trait instead of the deprecated previewLayout modifier

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_690c25aad64c832492657d45fbe65061