### PR TITLE
Add extra large preview variant for OnboardingView

### DIFF
--- a/ios/NudgeBud/NudgeBud/OnboardingView.swift
+++ b/ios/NudgeBud/NudgeBud/OnboardingView.swift
@@ -143,6 +143,12 @@ struct OnboardingView: View {
         .preferredColorScheme(.dark)
 }
 
+#Preview("Onboarding – XL") {
+    OnboardingView()
+        .preferredColorScheme(.light)
+        .environment(\.sizeCategory, .extraLarge)
+}
+
 private struct OnboardingHeroIllustration: View {
     @Environment(\.colorScheme) private var colorScheme
 


### PR DESCRIPTION
## Summary
- add an XL preview configuration for `OnboardingView`
- ensure the preview continues to rely on the existing design tokens across light and dark modes

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_690cee74d6bc8324a3a6f77ed4306aa9