### PR TITLE
Refine onboarding layout scrolling

### DIFF
--- a/ios/NudgeBud/NudgeBud/OnboardingView.swift
+++ b/ios/NudgeBud/NudgeBud/OnboardingView.swift
@@ -19,7 +19,7 @@ struct OnboardingView: View {
             DesignTokens.Colors.surface(for: colorScheme)
                 .ignoresSafeArea()
 
-            ScrollView {
+            ScrollView(showsIndicators: false) {
                 VStack(spacing: 32) {
                     heroCard
                     copySection
@@ -27,10 +27,10 @@ struct OnboardingView: View {
                     secondaryAction
                 }
                 // Keeping the layout centered and readable on large iPads.
-                .frame(maxWidth: DesignTokens.Layout.maxContentWidth)
+                .frame(maxWidth: DesignTokens.Layout.maxContentWidth, alignment: .center)
                 .padding(.horizontal, 24)
                 .padding(.vertical, 48)
-                .frame(maxWidth: .infinity)
+                .frame(maxWidth: .infinity, alignment: .center)
             }
         }
     }


### PR DESCRIPTION
## Summary
- hide onboarding scroll indicators to match the design's clean presentation
- center the scrollable content within the design token max width while preserving safe-area background fill

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_690cee5bef688324986952fd962904d4